### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/jake-walker/codl/compare/v0.1.1...v0.2.0) - 2024-12-03
+
+### Added
+
+- [**breaking**] parse process response
+
 ## [0.1.1](https://github.com/jake-walker/codl/compare/v0.1.0...v0.1.1) - 2024-12-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "codl"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codl"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A CLI and Rust library for interacting with cobalt, a media downloader"


### PR DESCRIPTION
## 🤖 New release
* `codl`: 0.1.1 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/jake-walker/codl/compare/v0.1.1...v0.2.0) - 2024-12-03

### Added

- [**breaking**] parse process response
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).