### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/jake-walker/codl/compare/v0.1.1...v0.2.0) - 2025-01-25
+
+### Added
+
+- [**breaking**] improve error handling
+- add download methods
+- [**breaking**] parse process response
+
+### Other
+
+- bump dependencies
+
 ## [0.1.1](https://github.com/jake-walker/codl/compare/v0.1.0...v0.1.1) - 2024-12-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "codl"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codl"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A CLI and Rust library for interacting with cobalt, a media downloader"


### PR DESCRIPTION
## 🤖 New release
* `codl`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `codl` breaking changes

```
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/method_parameter_count_changed.ron

Failed in:
  codl::Client::process now takes 2 parameters instead of 3, in /tmp/.tmpXgMvws/codl/src/lib.rs:194
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/jake-walker/codl/compare/v0.1.1...v0.2.0) - 2025-01-25

### Added

- [**breaking**] improve error handling
- add download methods
- [**breaking**] parse process response

### Other

- bump dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).